### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Options:
 
 
 example usage: sudo python warberry.py -a -T                Attack all TCP Ports
-               sudo python warberry.py --attack --toptcp    Scan only the top udp ports
+               sudo python warberry.py --attack --toptcp    Scan only the top tcp ports
                sudo python warberry.py -r                   Use only the recon modules
                sudo python warberry.py -H -I wlan0          Use the wlan0 interface and dont change hostname
                sudo python warberry.py -I eth0 -i -T3       Use the eth0 interface and T3 scanning intensity


### PR DESCRIPTION
In the examples section I have corrected a typo. The example usage flag of --attack --toptcp previously suggested that it would result in a scan of only UDP ports.