### PR TITLE
Fix setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -38,8 +38,9 @@ git clone https://github.com/SpiderLabs/Responder.git
 git clone https://github.com/PowerShellMafia/PowerSploit.git
 git clone https://github.com/offensive-security/exploit-database.git
 wget https://download.sysinternals.com/files/SysinternalsSuite.zip
-wget https://labs.portcullis.co.uk/download/enum4linux-0.8.9.tar.gz -O /home/pi/WarBerry/Tools/enum4linux-0.8.9.tar.gz
-tar -zxvf enum4linux-0.8.9.tar.gz
-mv enum4linux-0.8.9 enum4linux
+sudo pip install requests
+git clone https://github.com/portcullislabs/enum4linux.git
+sudo apt-get install -y libssl-dev libffi-dev python-dev
+sudo pip install crackmapexec
 cd /home/pi/WarBerry
 


### PR DESCRIPTION
- Updated enum4linux repo
- Added installation of cme (necessary for the tool)

I suggest you also to update "Installation" page of the wiki (unfortunately I can't create a pull request for that) in this way:

!!! OLD !!!

**Auto installation of dependencies**

`sudo bash bootstrap.sh`


!!! NEW !!!

**Auto installation of dependencies**

Optional: Change the hostname of the RaspberryPi to WarBerry

`sudo nano /etc/hosts`

`sudo nano /etc/hostname`

Reboot the WarBerry for the changes to take effect

Create a directory under /home/pi

`sudo mkdir WarBerry`

Download WarBerry by cloning the Git repository:

`sudo git clone https://github.com/secgroundzero/warberry.git`

Enter the directory of the cloned project

`cd warberry`

Auto installation of dependencies

`sudo bash setup.sh`